### PR TITLE
Update customer address fields

### DIFF
--- a/QuanView/Areas/Admin/Views/KhachHang/Edit.cshtml
+++ b/QuanView/Areas/Admin/Views/KhachHang/Edit.cshtml
@@ -1,23 +1,26 @@
-﻿@model QuanApi.Dtos.UpdateKhachHangDto
+@model QuanApi.Dtos.UpdateKhachHangDto
 
 @{
-    ViewData["Title"] = "Chỉnh sửa Khách Hàng và Địa Chỉ";
+    ViewData["Title"] = "Sửa Khách Hàng và Địa Chỉ";
     Layout = "_Layout";
 }
 
 <script src="https://cdn.tailwindcss.com"></script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<script src="https://esgoo.net/scripts/jquery.js"></script>
 
 <style>
     body {
         font-family: 'Inter', sans-serif;
         background-color: #f3f4f6;
     }
+
     .form-check-label {
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
+
     .form-check-input {
         margin-top: 0;
     }
@@ -27,17 +30,20 @@
     <div class="max-w-4xl w-full bg-white p-8 rounded-xl shadow-lg space-y-6">
         <h1 class="text-3xl font-extrabold text-gray-900 text-center">Chỉnh sửa Khách Hàng</h1>
         <p class="text-center text-gray-600">Cập nhật thông tin khách hàng và địa chỉ liên quan.</p>
+
         <hr class="my-6 border-gray-200" />
-        <form asp-action="Edit" method="post" id="editKhachHangForm" class="space-y-6">
-            @Html.AntiForgeryToken()
+
+        <form asp-action="Edit" id="editKhachHangForm" class="space-y-6">
             <div asp-validation-summary="ModelOnly" class="text-red-600 font-medium text-sm mb-4"></div>
+
             <input type="hidden" asp-for="IDKhachHang" />
+
             <div class="bg-gray-50 p-6 rounded-lg shadow-sm">
                 <h3 class="text-2xl font-semibold text-gray-800 mb-4">Thông tin Khách Hàng</h3>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div class="form-group">
                         <label asp-for="MaKhachHang" class="block text-sm font-medium text-gray-700 mb-1"></label>
-                        <input asp-for="MaKhachHang" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" />
+                        <input asp-for="MaKhachHang" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-gray-200 cursor-not-allowed sm:text-sm" readonly />
                         <span asp-validation-for="MaKhachHang" class="text-red-600 text-xs mt-1 block"></span>
                     </div>
                     <div class="form-group">
@@ -49,6 +55,11 @@
                         <label asp-for="Email" class="block text-sm font-medium text-gray-700 mb-1"></label>
                         <input asp-for="Email" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" />
                         <span asp-validation-for="Email" class="text-red-600 text-xs mt-1 block"></span>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="MatKhau" class="block text-sm font-medium text-gray-700 mb-1"></label>
+                        <input asp-for="MatKhau" type="password" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" />
+                        <span asp-validation-for="MatKhau" class="text-red-600 text-xs mt-1 block"></span>
                     </div>
                     <div class="form-group md:col-span-2">
                         <label asp-for="SoDienThoai" class="block text-sm font-medium text-gray-700 mb-1"></label>
@@ -63,6 +74,7 @@
                     </div>
                 </div>
             </div>
+
             <div class="bg-gray-50 p-6 rounded-lg shadow-sm">
                 <h3 class="text-2xl font-semibold text-gray-800 mb-4 flex items-center justify-between">
                     Địa Chỉ
@@ -76,86 +88,63 @@
                 <div id="addressesContainer" class="space-y-4">
                 </div>
             </div>
+
             <div class="form-group mt-6 text-center">
                 <button type="submit" class="w-full sm:w-auto inline-flex justify-center py-3 px-6 border border-transparent shadow-sm text-lg font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition ease-in-out duration-150">
-                    Lưu thay đổi
+                    Cập nhật Khách Hàng
                 </button>
             </div>
         </form>
+
         <div class="mt-8 text-center">
             <a asp-action="Index" class="text-indigo-600 hover:text-indigo-900 font-medium">Quay lại danh sách</a>
         </div>
     </div>
 </div>
+
 @section Scripts {
     @{
         await Html.RenderPartialAsync("_ValidationScriptsPartial");
     }
+
     <script>
         let addressIndex = 0;
-        function renderAddresses(addresses) {
-            const container = document.getElementById('addressesContainer');
-            container.innerHTML = '';
-            addresses.forEach((address, idx) => {
-                const newAddressForm = document.createElement('div');
-                newAddressForm.classList.add('address-item', 'bg-white', 'p-5', 'rounded-lg', 'shadow-md', 'space-y-4', 'border', 'border-gray-200');
-                newAddressForm.innerHTML = `
-                    <div class=\"flex items-center justify-between mb-3\">
-                        <h4 class=\"text-lg font-medium text-gray-800\">Địa chỉ #${idx + 1}</h4>
-                        <button type=\"button\" class=\"btn btn-sm btn-danger remove-address-btn inline-flex items-center px-3 py-1 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition ease-in-out duration-150\">
-                            <svg class=\"-ml-0.5 mr-1 h-4 w-4\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\">
-                                <path fill-rule=\"evenodd\" d=\"M9 2a1 1 0 00-1 1v1H5a1 1 0 000 2h1v9a2 2 0 002 2h4a2 2 0 002-2V6h1a1 1 0 100-2h-3V3a1 1 0 00-1-1H9zm0 2h2v1H9V4zm0 3a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1zm4 0a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z\" clip-rule=\"evenodd\" />
-                            </svg>
-                            Xóa
-                        </button>
-                    </div>
-                    <input type=\"hidden\" name=\"DiaChis[${idx}].IDDiaChi\" value=\"${address.idDiaChi || ''}\" />
-                    <div class=\"grid grid-cols-1 md:grid-cols-2 gap-4\">
-                        <div class=\"form-group\">
-                            <label for=\"DiaChis_${idx}__MaDiaChi\" class=\"block text-sm font-medium text-gray-700 mb-1\">Mã địa chỉ</label>
-                            <input name=\"DiaChis[${idx}].MaDiaChi\" id=\"DiaChis_${idx}__MaDiaChi\" class=\"mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm\" value=\"${address.maDiaChi || ''}\" required />
-                            <span data-valmsg-for=\"DiaChis[${idx}].MaDiaChi\" class=\"text-red-600 text-xs mt-1 block\"></span>
-                        </div>
-                        <div class=\"form-group md:col-span-2\">
-                            <label for=\"DiaChis_${idx}__DiaChiChiTiet\" class=\"block text-sm font-medium text-gray-700 mb-1\">Địa chỉ chi tiết</label>
-                            <input name=\"DiaChis[${idx}].DiaChiChiTiet\" id=\"DiaChis_${idx}__DiaChiChiTiet\" class=\"mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm\" value=\"${address.diaChiChiTiet || ''}\" required />
-                            <span data-valmsg-for=\"DiaChis[${idx}].DiaChiChiTiet\" class=\"text-red-600 text-xs mt-1 block\"></span>
-                        </div>
-                        <div class=\"form-group\">
-                            <label for=\"DiaChis_${idx}__TenNguoiNhan\" class=\"block text-sm font-medium text-gray-700 mb-1\">Tên người nhận</label>
-                            <input name=\"DiaChis[${idx}].TenNguoiNhan\" id=\"DiaChis_${idx}__TenNguoiNhan\" class=\"mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm\" value=\"${address.tenNguoiNhan || ''}\" />
-                            <span data-valmsg-for=\"DiaChis[${idx}].TenNguoiNhan\" class=\"text-red-600 text-xs mt-1 block\"></span>
-                        </div>
-                        <div class=\"form-group\">
-                            <label for=\"DiaChis_${idx}__SdtNguoiNhan\" class=\"block text-sm font-medium text-gray-700 mb-1\">SĐT người nhận</label>
-                            <input name=\"DiaChis[${idx}].SdtNguoiNhan\" id=\"DiaChis_${idx}__SdtNguoiNhan\" class=\"mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm\" value=\"${address.sdtNguoiNhan || ''}\" />
-                            <span data-valmsg-for=\"DiaChis[${idx}].SdtNguoiNhan\" class=\"text-red-600 text-xs mt-1 block\"></span>
-                        </div>
-                        <div class=\"form-group form-check\">
-                            <label class=\"form-check-label inline-flex items-center text-sm text-gray-700\">
-                                <input type=\"checkbox\" name=\"DiaChis[${idx}].LaMacDinh\" id=\"DiaChis_${idx}__LaMacDinh\" class=\"form-check-input h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500\" value=\"true\" ${address.laMacDinh ? 'checked' : ''} />
-                                <span class=\"ml-2\">Là mặc định</span>
-                            </label>
-                            <input type=\"hidden\" name=\"DiaChis[${idx}].LaMacDinh\" value=\"false\" />
-                        </div>
-                        <div class=\"form-group form-check\">
-                            <label class=\"form-check-label inline-flex items-center text-sm text-gray-700\">
-                                <input type=\"checkbox\" name=\"DiaChis[${idx}].TrangThai\" id=\"DiaChis_${idx}__TrangThai\" class=\"form-check-input h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500\" value=\"true\" ${address.trangThai !== false ? 'checked' : ''} />
-                                <span class=\"ml-2\">Trạng thái</span>
-                            </label>
-                            <input type=\"hidden\" name=\"DiaChis[${idx}].TrangThai\" value=\"false\" />
-                        </div>
-                    </div>
-                `;
-                container.appendChild(newAddressForm);
-                newAddressForm.querySelector('.remove-address-btn').addEventListener('click', function() {
-                    newAddressForm.remove();
-                    updateAddressIndices();
-                });
-            });
-            addressIndex = addresses.length;
+
+        function updateAddressString(formElement) {
+            const diaChiChiTietInput = formElement.querySelector('[name$="DiaChiChiTiet"]');
+            const diaChiDayDuInput = formElement.querySelector('[name$="DiaChiDayDu"]');
+
+            const phuongXa = formElement.querySelector('[name$="PhuongXa"]').value || '';
+            const quanHuyen = formElement.querySelector('[name$="QuanHuyen"]').value || '';
+            const tinhThanh = formElement.querySelector('[name$="TinhThanh"]').value || '';
+            const soNhaTenDuong = formElement.querySelector('[name$="SoNhaTenDuong"]').value || '';
+
+            // Ghép chuỗi địa chỉ: số nhà, tên đường + phường/xã + quận/huyện + tỉnh/thành phố
+            const addressParts = [soNhaTenDuong, phuongXa, quanHuyen, tinhThanh].filter(part => part !== '');
+            const fullAddress = addressParts.join(', ');
+
+            // Lưu địa chỉ đầy đủ vào DiaChiChiTiet và DiaChiDayDu
+            diaChiChiTietInput.value = fullAddress;
+            diaChiDayDuInput.value = fullAddress;
         }
-        function addAddressForm() {
+
+        function populateAddress(formElement, addressData) {
+            if (addressData) {
+                formElement.querySelector('[name$="MaDiaChi"]').value = addressData.maDiaChi;
+                formElement.querySelector('[name$="TenNguoiNhan"]').value = addressData.tenNguoiNhan;
+                formElement.querySelector('[name$="SdtNguoiNhan"]').value = addressData.sdtNguoiNhan;
+
+                // Handle checkboxes
+                formElement.querySelector('[name$="LaMacDinh"]').checked = addressData.laMacDinh;
+                formElement.querySelector('[name$="TrangThai"]').checked = addressData.trangThai;
+
+                // Set hidden inputs for checkboxes to prevent them from being lost if unchecked
+                formElement.querySelector('[name$="LaMacDinh"][type="hidden"]').value = addressData.laMacDinh ? "true" : "false";
+                formElement.querySelector('[name$="TrangThai"][type="hidden"]').value = addressData.trangThai ? "true" : "false";
+            }
+        }
+
+        function addAddressForm(addressData = null) {
             const container = document.getElementById('addressesContainer');
             const newAddressForm = document.createElement('div');
             newAddressForm.classList.add('address-item', 'bg-white', 'p-5', 'rounded-lg', 'shadow-md', 'space-y-4', 'border', 'border-gray-200');
@@ -169,17 +158,49 @@
                         Xóa
                     </button>
                 </div>
+                <input type="hidden" name="DiaChis.Index" value="${addressIndex}" />
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div class="form-group">
                         <label for="DiaChis_${addressIndex}__MaDiaChi" class="block text-sm font-medium text-gray-700 mb-1">Mã địa chỉ</label>
                         <input name="DiaChis[${addressIndex}].MaDiaChi" id="DiaChis_${addressIndex}__MaDiaChi" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" required />
                         <span data-valmsg-for="DiaChis[${addressIndex}].MaDiaChi" class="text-red-600 text-xs mt-1 block"></span>
                     </div>
-                    <div class="form-group md:col-span-2">
-                        <label for="DiaChis_${addressIndex}__DiaChiChiTiet" class="block text-sm font-medium text-gray-700 mb-1">Địa chỉ chi tiết</label>
-                        <input name="DiaChis[${addressIndex}].DiaChiChiTiet" id="DiaChis_${addressIndex}__DiaChiChiTiet" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" required />
-                        <span data-valmsg-for="DiaChis[${addressIndex}].DiaChiChiTiet" class="text-red-600 text-xs mt-1 block"></span>
+
+                    <div class="form-group">
+                        <label for="DiaChis_${addressIndex}__TinhThanh" class="block text-sm font-medium text-gray-700 mb-1">Tỉnh/Thành phố</label>
+                        <select name="DiaChis[${addressIndex}].TinhThanh" id="DiaChis_${addressIndex}__TinhThanh" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm tinh-select" required>
+                            <option value="">-- Chọn Tỉnh/Thành phố --</option>
+                        </select>
+                        <span data-valmsg-for="DiaChis[${addressIndex}].TinhThanh" class="text-red-600 text-xs mt-1 block"></span>
                     </div>
+                    <div class="form-group">
+                        <label for="DiaChis_${addressIndex}__QuanHuyen" class="block text-sm font-medium text-gray-700 mb-1">Quận/Huyện</label>
+                        <select name="DiaChis[${addressIndex}].QuanHuyen" id="DiaChis_${addressIndex}__QuanHuyen" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm quan-select" required>
+                            <option value="">-- Chọn Quận/Huyện --</option>
+                        </select>
+                        <span data-valmsg-for="DiaChis[${addressIndex}].QuanHuyen" class="text-red-600 text-xs mt-1 block"></span>
+                    </div>
+                    <div class="form-group">
+                        <label for="DiaChis_${addressIndex}__PhuongXa" class="block text-sm font-medium text-gray-700 mb-1">Phường/Xã</label>
+                        <select name="DiaChis[${addressIndex}].PhuongXa" id="DiaChis_${addressIndex}__PhuongXa" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm phuong-select" required>
+                            <option value="">-- Chọn Phường/Xã --</option>
+                        </select>
+                        <span data-valmsg-for="DiaChis[${addressIndex}].PhuongXa" class="text-red-600 text-xs mt-1 block"></span>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="DiaChis_${addressIndex}__SoNhaTenDuong" class="block text-sm font-medium text-gray-700 mb-1">Số nhà, tên đường</label>
+                        <input name="DiaChis[${addressIndex}].SoNhaTenDuong" id="DiaChis_${addressIndex}__SoNhaTenDuong" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" placeholder="Số nhà, tên đường..." />
+                        <span data-valmsg-for="DiaChis[${addressIndex}].SoNhaTenDuong" class="text-red-600 text-xs mt-1 block"></span>
+                    </div>
+
+                    <div class="form-group md:col-span-2">
+                        <label for="DiaChis_${addressIndex}__DiaChiDayDu" class="block text-sm font-medium text-gray-700 mb-1">Địa chỉ đầy đủ</label>
+                        <input name="DiaChis[${addressIndex}].DiaChiDayDu" id="DiaChis_${addressIndex}__DiaChiDayDu" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm bg-gray-200 cursor-not-allowed" readonly />
+                    </div>
+
+                    <input type="hidden" name="DiaChis[${addressIndex}].DiaChiChiTiet" id="DiaChis_${addressIndex}__DiaChiChiTiet" />
+
                     <div class="form-group">
                         <label for="DiaChis_${addressIndex}__TenNguoiNhan" class="block text-sm font-medium text-gray-700 mb-1">Tên người nhận</label>
                         <input name="DiaChis[${addressIndex}].TenNguoiNhan" id="DiaChis_${addressIndex}__TenNguoiNhan" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" />
@@ -207,17 +228,110 @@
                 </div>
             `;
             container.appendChild(newAddressForm);
+
+            const tinhSelect = newAddressForm.querySelector('.tinh-select');
+            const quanSelect = newAddressForm.querySelector('.quan-select');
+            const phuongSelect = newAddressForm.querySelector('.phuong-select');
+            const soNhaTenDuongInput = newAddressForm.querySelector('[name$="SoNhaTenDuong"]');
+
+            const updateHandler = () => updateAddressString(newAddressForm);
+            soNhaTenDuongInput.addEventListener('input', updateHandler);
+
             newAddressForm.querySelector('.remove-address-btn').addEventListener('click', function() {
                 newAddressForm.remove();
                 updateAddressIndices();
             });
+
+            // Fetch provinces
+            $.getJSON('https://esgoo.net/api-tinhthanh/1/0.htm', function(data_tinh) {
+                if (data_tinh.error === 0) {
+                    $.each(data_tinh.data, function (key, val) {
+                        $(tinhSelect).append('<option value="' + val.full_name + '" data-id="' + val.id + '">' + val.full_name + '</option>');
+                    });
+                }
+
+                // Set initial value for TinhThanh if data exists
+                if (addressData) {
+                    const existingTinh = addressData.tinhThanh;
+                    const optionToSelect = $(tinhSelect).find(`option[value="${existingTinh}"]`);
+                    if (optionToSelect.length) {
+                        optionToSelect.prop('selected', true);
+                        $(tinhSelect).trigger('change');
+                    }
+                }
+            });
+
+            // Handle TinhThanh change
+            $(tinhSelect).change(function() {
+                const idtinh = $(this).find('option:selected').data('id');
+                $(quanSelect).html('<option value="">-- Chọn Quận/Huyện --</option>');
+                $(phuongSelect).html('<option value="">-- Chọn Phường/Xã --</option>');
+
+                if (idtinh) {
+                    $.getJSON('https://esgoo.net/api-tinhthanh/2/' + idtinh + '.htm', function(data_quan) {
+                        if (data_quan.error === 0) {
+                            $.each(data_quan.data, function (key, val) {
+                                $(quanSelect).append('<option value="' + val.full_name + '" data-id="' + val.id + '">' + val.full_name + '</option>');
+                            });
+                            // Set initial value for QuanHuyen if data exists
+                            if (addressData) {
+                                const existingQuan = addressData.quanHuyen;
+                                const optionToSelect = $(quanSelect).find(`option[value="${existingQuan}"]`);
+                                if (optionToSelect.length) {
+                                    optionToSelect.prop('selected', true);
+                                    $(quanSelect).trigger('change');
+                                }
+                            }
+                        }
+                    });
+                }
+                updateHandler();
+            });
+
+            // Handle QuanHuyen change
+            $(quanSelect).change(function() {
+                const idquan = $(this).find('option:selected').data('id');
+                $(phuongSelect).html('<option value="">-- Chọn Phường/Xã --</option>');
+
+                if (idquan) {
+                    $.getJSON('https://esgoo.net/api-tinhthanh/3/' + idquan + '.htm', function(data_phuong) {
+                        if (data_phuong.error === 0) {
+                            $.each(data_phuong.data, function (key, val) {
+                                $(phuongSelect).append('<option value="' + val.full_name + '">' + val.full_name + '</option>');
+                            });
+                            // Set initial value for PhuongXa if data exists
+                            if (addressData) {
+                                const existingPhuong = addressData.phuongXa;
+                                const optionToSelect = $(phuongSelect).find(`option[value="${existingPhuong}"]`);
+                                if (optionToSelect.length) {
+                                    optionToSelect.prop('selected', true);
+                                }
+                            }
+                        }
+                    });
+                }
+                updateHandler();
+            });
+
+            phuongSelect.addEventListener('change', updateHandler);
+            soNhaTenDuongInput.addEventListener('input', updateHandler);
+
+            // Populate other fields if data is provided
+            if (addressData) {
+                populateAddress(newAddressForm, addressData);
+            }
+
+            // Call validator unobtrusive on the newly added form section
             const form = document.getElementById('editKhachHangForm');
             $.validator.unobtrusive.parse(form);
+
             addressIndex++;
         }
+
         function updateAddressIndices() {
             const addressItems = document.querySelectorAll('#addressesContainer .address-item');
             addressItems.forEach((item, index) => {
+                // Update names and IDs
                 item.querySelectorAll('[name^="DiaChis["]').forEach(input => {
                     const oldName = input.getAttribute('name');
                     const newName = oldName.replace(/DiaChis\[\d+\]/, `DiaChis[${index}]`);
@@ -234,18 +348,29 @@
                     span.setAttribute('data-valmsg-for', newValMsgFor);
                 });
                 item.querySelector('h4').textContent = `Địa chỉ #${index + 1}`;
+
+                // Update the hidden index field for ASP.NET MVC binding
+                const hiddenIndexInput = item.querySelector('input[name="DiaChis.Index"]');
+                if (hiddenIndexInput) {
+                    hiddenIndexInput.value = index;
+                }
             });
             addressIndex = addressItems.length;
         }
+
         document.addEventListener('DOMContentLoaded', function () {
-            // Lấy dữ liệu DiaChis từ model Razor sang JS
-            var diaChis = @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(Model.DiaChis ?? new List<QuanApi.Dtos.DiaChiDto>()))
-            if (diaChis.length > 0) {
-                renderAddresses(diaChis);
+            document.getElementById('addAddressBtn').addEventListener('click', function() {
+                addAddressForm();
+            });
+
+            const existingAddresses = @Html.Raw(Json.Serialize(Model.DiaChis ?? new List<QuanApi.Dtos.DiaChiDto>()));
+            if (existingAddresses && existingAddresses.length > 0) {
+                existingAddresses.forEach(address => {
+                    addAddressForm(address);
+                });
             } else {
                 addAddressForm();
             }
-            document.getElementById('addAddressBtn').addEventListener('click', addAddressForm);
         });
     </script>
 }


### PR DESCRIPTION
Concatenate province, district, and ward selections with street name into a single detailed address string for customer edits to simplify address storage.

The previous implementation saved province, district, and ward as separate fields. This change combines them into a single `DiaChiChiTiet` field, formatted as "Số nhà, tên đường, Phường/Xã, Quận/Huyện, Tỉnh/Thành phố", which is also reflected in `DiaChiDayDu`. This aligns with the requirement to store the full address as a single string. Dynamic dropdowns for location selection are maintained and populated from `esgoo.net` API.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef07d829-72f8-4514-8403-89e9b7305346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef07d829-72f8-4514-8403-89e9b7305346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

